### PR TITLE
Fix way to use crates in scripts 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
+moka = { version = "0.11", features = ["future"] }
 json = { package = "serde_json", version = "1.0" }
+serde = { version = "1.0", features = ["derive"] }
 
 rocket = { version = "=0.5.0-rc.3", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 moka = { version = "0.11", features = ["future"] }
-json = { package = "serde_json", version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 
 rocket = { version = "=0.5.0-rc.3", features = ["json"] }
+json = { version = "1.0", package = "serde_json", features = ["raw_value"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,14 @@ mod script;
 
 use {
     moka::future::Cache,
-    rocket::{response::content::RawJson, serde::json::Json},
+    rocket::{response::content::RawJson, serde::json::Json, State},
     std::{
         borrow, env,
         sync::atomic::{AtomicUsize, Ordering},
     },
 };
 
-use rocket::{get, post, routes, State};
+use rocket::{get, post, routes};
 
 #[derive(serde::Deserialize)]
 pub struct Call<'a> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod script;
 
 use {
+    json::value::RawValue,
     moka::future::Cache,
     rocket::{response::content::RawJson, serde::json::Json, State},
     std::{
@@ -15,10 +16,14 @@ use rocket::{get, post, routes};
 
 #[derive(serde::Deserialize)]
 pub struct Call<'a> {
-    #[serde(default)]
+    #[serde(default, borrow)]
     head: borrow::Cow<'a, str>,
+
+    #[serde(borrow)]
     main: borrow::Cow<'a, str>,
-    args: json::Value,
+
+    #[serde(borrow)]
+    args: &'a RawValue,
 }
 
 // fixme: possible to use in config, it is very easy - https://crates.io/keywords/configuration
@@ -26,7 +31,7 @@ const CRATES: &str = "crates";
 
 #[post("/call", data = "<call>")]
 async fn call(
-    call: Json<Call<'static>>,
+    call: Json<Call<'_>>,
     scripts: &State<Scripts>,
 ) -> Result<RawJson<String>, script::Error> {
     static COUNT: AtomicUsize = AtomicUsize::new(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::let_unit_value)] // false positive: https://github.com/SergioBenitez/Rocket/issues/2568
-#![deny(clippy::pedantic)]
 
 mod script;
 
@@ -16,6 +15,7 @@ use rocket::{get, post, routes, State};
 
 #[derive(serde::Deserialize)]
 pub struct Call<'a> {
+    #[serde(default)]
     head: borrow::Cow<'a, str>,
     main: borrow::Cow<'a, str>,
     args: json::Value,

--- a/src/script.rs
+++ b/src/script.rs
@@ -55,7 +55,7 @@ pub async fn execute_in(
     .await?;
 
     let out = Command::new("rust-script")
-        .arg("-d serde_json=1.0")
+        .args(["-d", "serde_json=1.0"])
         .arg(path.join(file))
         .arg(args.to_string())
         .output()

--- a/src/script.rs
+++ b/src/script.rs
@@ -57,7 +57,7 @@ pub async fn execute_in(
     let out = Command::new("rust-script")
         .args(["-d", "serde_json=1.0"])
         .arg(path.join(file))
-        .arg(args.to_string())
+        .arg(args.get())
         .output()
         .await?;
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -45,16 +45,21 @@ pub async fn execute_in(
             r##"
             {head}
             
-            fn main() -> Result<(), Box<dyn std::error::Error>> {{ 
-                let args = serde_json::from_str(r#"{args}"#)?; 
+            fn main() -> Result<(), Box<dyn std::error::Error>> {{
+                let args = std::env::args().skip(1).next().unwrap();
+                let args = serde_json::from_str(&args)?; 
                 {main} println!("{{}}", serde_json::to_string(&main(args))?); Ok(()) 
             }}"##
         ),
     )
     .await?;
 
-    let out =
-        Command::new("rust-script").arg("-d serde_json=1.0").arg(path.join(file)).output().await?;
+    let out = Command::new("rust-script")
+        .arg("-d serde_json=1.0")
+        .arg(path.join(file))
+        .arg(args.to_string())
+        .output()
+        .await?;
 
     if out.status.success() {
         Ok(String::from_utf8(out.stdout)?)


### PR DESCRIPTION
- use `borrow::Cow`, because `&str` cannot work on multiline strings (serde transmute `\n` into two chars)
- pass arguments into `execute_in` forward by `Call`
- split `code` into `head` and `main` follows the `suckless` philosophy -> `head` for cargo manifest and something like `#![feature(...)]`, `main` for main...